### PR TITLE
security: validate JSONP callback to prevent reflected XSS

### DIFF
--- a/abcode/web/webtc/getword.php
+++ b/abcode/web/webtc/getword.php
@@ -13,8 +13,15 @@ function getwordCall() {
   $temp = new GetwordClass();
   $table1 = $temp->table1;
   if (isset($_GET['callback'])) {
+   $callback = $_GET['callback'];
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
    $json = json_encode($table1);
-   echo "{$_GET['callback']}($json)";
+   echo "{$callback}($json)";
   }else {
    echo $table1;
   }

--- a/abcode/web/webtc2/query.php
+++ b/abcode/web/webtc2/query.php
@@ -33,7 +33,14 @@ $lastLnum = $model->lastLnum;
 $ans = construct_outputarr($getParms,$model,$dictcode,$getParms->filter);
 $json = json_encode($ans);
 if(isset($_GET['callback'])) {
- echo "{$_GET['callback']}($json)";
+ $callback = $_GET['callback'];
+ if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+  header('content-type: text/plain; charset=utf-8');
+  http_response_code(400);
+  echo "invalid callback";
+  exit;
+ }
+ echo "{$callback}($json)";
 }else {
  echo $json;
 }

--- a/web/webtc/getword.php
+++ b/web/webtc/getword.php
@@ -13,8 +13,15 @@ function getwordCall() {
   $temp = new GetwordClass();
   $table1 = $temp->table1;
   if (isset($_GET['callback'])) {
+   $callback = $_GET['callback'];
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
    $json = json_encode($table1);
-   echo "{$_GET['callback']}($json)";
+   echo "{$callback}($json)";
   }else {
    echo $table1;
   }

--- a/web/webtc2/query.php
+++ b/web/webtc2/query.php
@@ -33,7 +33,14 @@ $lastLnum = $model->lastLnum;
 $ans = construct_outputarr($getParms,$model,$dictcode,$getParms->filter);
 $json = json_encode($ans);
 if(isset($_GET['callback'])) {
- echo "{$_GET['callback']}($json)";
+ $callback = $_GET['callback'];
+ if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+  header('content-type: text/plain; charset=utf-8');
+  http_response_code(400);
+  echo "invalid callback";
+  exit;
+ }
+ echo "{$callback}($json)";
 }else {
  echo $json;
 }


### PR DESCRIPTION
## Reflected XSS via JSONP `callback` parameter

Two MW web endpoints echoed the **raw** `$_GET['callback']` directly into the JSONP response body:

- [`web/webtc/getword.php`](https://github.com/sanskrit-lexicon/mw-dev/blob/main/web/webtc/getword.php) (and its source copy [`abcode/web/webtc/getword.php`](https://github.com/sanskrit-lexicon/mw-dev/blob/main/abcode/web/webtc/getword.php))
- [`web/webtc2/query.php`](https://github.com/sanskrit-lexicon/mw-dev/blob/main/web/webtc2/query.php) (and its source copy [`abcode/web/webtc2/query.php`](https://github.com/sanskrit-lexicon/mw-dev/blob/main/abcode/web/webtc2/query.php))

```php
echo "{$_GET['callback']}($json)";   // before
```

A request like `?...&callback=<script>alert(1)</script>` is reflected verbatim, so a crafted link executes arbitrary JavaScript in the victim's browser.

## Fix

Validate the callback against a strict JavaScript-identifier whitelist and return **HTTP 400** on mismatch before echoing it — the same canonical pattern already merged in sibling repos:

```php
$callback = $_GET['callback'];
if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
  header('content-type: text/plain; charset=utf-8');
  http_response_code(400);
  echo "invalid callback";
  return;   // exit; in the top-level query.php
}
echo "{$callback}($json)";
```

Both the live `web/` tree and the `abcode/web/` source copy are fixed so the fix survives regeneration.

## Verification

- `php -l` clean on all 4 files (PHP 8.2).
- Valid callbacks (`[A-Za-z_$][A-Za-z0-9_$.]*`) are unaffected; only malformed callbacks are rejected.

Part of the org-wide reflected-XSS / JSONP sweep following sanskrit-lexicon/csl-websanlexicon#27, #63, #67 and the canonical fix in sanskrit-lexicon/GRA#44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)