### PR TITLE
security: guard JSONP callback against array injection (is_string)

### DIFF
--- a/abcode/web/webtc/getword.php
+++ b/abcode/web/webtc/getword.php
@@ -14,7 +14,7 @@ function getwordCall() {
   $table1 = $temp->table1;
   if (isset($_GET['callback'])) {
    $callback = $_GET['callback'];
-   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+   if (!is_string($callback) || !preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
     header('content-type: text/plain; charset=utf-8');
     http_response_code(400);
     echo "invalid callback";

--- a/abcode/web/webtc2/query.php
+++ b/abcode/web/webtc2/query.php
@@ -34,7 +34,7 @@ $ans = construct_outputarr($getParms,$model,$dictcode,$getParms->filter);
 $json = json_encode($ans);
 if(isset($_GET['callback'])) {
  $callback = $_GET['callback'];
- if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+ if (!is_string($callback) || !preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
   header('content-type: text/plain; charset=utf-8');
   http_response_code(400);
   echo "invalid callback";

--- a/web/webtc/getword.php
+++ b/web/webtc/getword.php
@@ -14,7 +14,7 @@ function getwordCall() {
   $table1 = $temp->table1;
   if (isset($_GET['callback'])) {
    $callback = $_GET['callback'];
-   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+   if (!is_string($callback) || !preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
     header('content-type: text/plain; charset=utf-8');
     http_response_code(400);
     echo "invalid callback";

--- a/web/webtc2/query.php
+++ b/web/webtc2/query.php
@@ -34,7 +34,7 @@ $ans = construct_outputarr($getParms,$model,$dictcode,$getParms->filter);
 $json = json_encode($ans);
 if(isset($_GET['callback'])) {
  $callback = $_GET['callback'];
- if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+ if (!is_string($callback) || !preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
   header('content-type: text/plain; charset=utf-8');
   http_response_code(400);
   echo "invalid callback";


### PR DESCRIPTION
Follow-up to [#27](https://github.com/sanskrit-lexicon/mw-dev/pull/27).

## Problem

The callback whitelist landed in #27 passes `$_GET['callback']` straight to `preg_match()`. A request like `?...&callback[]=x` makes `$_GET['callback']` an **array**, so:

```php
$callback = $_GET['callback'];                 // array
preg_match('/^[A-Za-z_$].../',$callback)       // TypeError under PHP 8
```

`preg_match()` with an array `$subject` throws a **`TypeError`** — a thrown `Error`, which `error_reporting(E_ALL & ~E_NOTICE & ~E_WARNING)` does **not** suppress — so the request fatals with **HTTP 500** (and leaks the file path if `display_errors` is on). Not XSS, but an unauthenticated 500 / info-disclosure.

## Fix

Short-circuit on non-strings so they take the clean 400 path, matching the more robust pattern already in [MWS #210](https://github.com/sanskrit-lexicon/MWS/pull/210):

```php
if (!is_string($callback) || !preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
```

Applied to all four files (`web/` + `abcode/web/`, getword.php + webtc2/query.php).

## Verification

- `php -l` clean on all 4 (PHP 8.2).
- `?callback[]=x` → rejected via the 400 path, **no TypeError**.
- Valid callbacks (e.g. `angular.callbacks._0`) → still accepted, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)